### PR TITLE
Improvements to docs, and specifying arguments via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,17 @@ $ make install
 
 ## Using the provider
 
-Please see the [examples](examples) directory for an example on how to use each.
+Please see the [examples](examples) directory for an example on how to use each resource and data source.
+
+The provider itself requires your CloudCraft API key to be specified (and has two further optional arguments). This can be done either as an argument in your `provider` block, or through an environment variables.
+
+### Provider Arguments
+
+| Argument Name | Environment Variable     | Type              | Description                               | Required? | Default             |
+|---------------|--------------------------|-------------------|-------------------------------------------|-----------|---------------------|
+| `apikey`      | `CLOUDCRAFT_APIKEY`      | String, Sensitive | API Key for CloudCraft                    | Yes       |                     |
+| `baseurl`     | `CLOUDCRAFT_BASEURL`     | String            | Host URL for cloudcraft.                  | No        | `api.cloudcraft.co` |
+| `max_retries` | `CLOUDCRAFT_MAX_RETRIES` | Number            | Max retries for each CloudCraft API call. | No        | `1`                 |
 
 ## Developing the Provider
 

--- a/cloudcraft/provider.go
+++ b/cloudcraft/provider.go
@@ -20,13 +20,13 @@ func Provider() *schema.Provider {
 			"baseurl": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CLOUDCRAFT_HOST", nil),
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDCRAFT_HOST", "api.cloudcraft.co"),
 				Description: "Host URL for cloudcraft",
 			},
 			"max_retries": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     1,
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDCRAFT_MAX_RETRIES", 1),
 				Description: "Max Retries",
 			},
 		},

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 page_title: "cloudcraft Provider"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # cloudcraft Provider
@@ -15,9 +15,9 @@ description: |-
 
 ### Required
 
-- **apikey** (String, Sensitive) apikey for cloudcraft
+- **apikey** (String, Sensitive) apikey for cloudcraft, can be set using environment variable `CLOUDCRAFT_APITOKEN`
 
 ### Optional
 
-- **baseurl** (String) Host URL for cloudcraft
-- **max_retries** (Number) Max Retries
+- **baseurl** (String) Host URL for cloudcraft, can be set using environment variable, `CLOUDCRAFT_HOST`
+- **max_retries** (Number) Max Retries, can be set using environment variable `CLOUDCRAFT_MAX_RETRIES` (defaults to 1).


### PR DESCRIPTION
Hello - thanks for creating this provider. It's really useful for both my day job and side projects! I've had a couple of issues using it the last month or two, and so thought I'd fix these with this pull request. 

Specifically, this PR should:

* Make it clearer how to specify provider arguments as environment variables
* Allow `max_retries` to be specified using the environment variable `CLOUDCRAFT_MAX_RETRIES`
* Provides a default argument for `baseurl` - `api.cloudcraft.co` (I've found that not specifying this can cause mysterious permissions errors)

Hope these changes work, please let me know if any further details are needed etc.!